### PR TITLE
fix: Qryn v.Bun + Telegraf

### DIFF
--- a/configs/telegraf.conf
+++ b/configs/telegraf.conf
@@ -59,10 +59,11 @@
   urls = ["http://vmagent:8429"]
   skip_database_creation = true
 
-#[[outputs.influxdb_v2]]
-#  urls = ["http://test:test@qryn:3100/influx"]
+[[outputs.influxdb_v2]]
+  urls = ["http://test:test@qryn:3100/influx"]
   #token = "dGVzdDp0ZXN0"
-  #http_headers = {"Authorization" = "Basic dGVzdDp0ZXN0"}
+  http_headers = {"Authorization" = "Basic dGVzdDp0ZXN0"}
+  content_encoding = "identity"
 
 # https://github.com/influxdata/telegraf/tree/master/plugins/outputs/http
 #[[outputs.http]]

--- a/minio-service.yml
+++ b/minio-service.yml
@@ -12,7 +12,7 @@ services:
       MINIO_ROOT_PASSWORD: minio123
     command: server --address :9001 /data1-1
     healthcheck:
-      test: "timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1"
+      test: "timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9001' || exit 1"
       interval: 5s
       retries: 1
       start_period: 5s

--- a/minio-service.yml
+++ b/minio-service.yml
@@ -12,7 +12,7 @@ services:
       MINIO_ROOT_PASSWORD: minio123
     command: server --address :9001 /data1-1
     healthcheck:
-      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      test: "timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1"
       interval: 5s
       retries: 1
       start_period: 5s

--- a/minio-service.yml
+++ b/minio-service.yml
@@ -11,3 +11,9 @@ services:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
     command: server --address :9001 /data1-1
+    healthcheck:
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      interval: 5s
+      retries: 1
+      start_period: 5s
+      timeout: 5s

--- a/qryn.yml
+++ b/qryn.yml
@@ -14,3 +14,4 @@ services:
       - STORAGE_POLICY=external
       - QRYN_LOGIN=test
       - QRYN_PASSWORD=test
+      - ADVANCED_TELEGRAF_METRICS_SCHEMA=telegraf-prometheus-v2


### PR DESCRIPTION
- gzip off (for Bun support)
- healthcheck for minio
- metrics schema support for the telegraf output
